### PR TITLE
Issue #5: Disable node caching for Ubercart products (only).

### DIFF
--- a/uc_price_per_role.module
+++ b/uc_price_per_role.module
@@ -85,8 +85,11 @@ function uc_price_per_role_menu_alter(&$items) {
  * Implements hook_entity_info_alter().
  */
 function uc_price_per_role_entity_info_alter(&$entity_info) {
-  // Disable node caching so that different roles can see varying node pricing.
-  $entity_info['node']['entity cache'] = FALSE;
+  // Disable node caching for Ubercart products so that different roles can see
+  // varying node pricing.
+  foreach (uc_product_types() as $type) {
+    $entity_info['node']['bundles'][$type]['bundle cache'] = FALSE;
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/uc_price_per_role/issues/5.

Instead if disabling node caching entirely, we disable it only for those nodes that are Ubercart products.